### PR TITLE
Fix a problem with custom default order pending status.

### DIFF
--- a/Controller/Invoice/Index.php
+++ b/Controller/Invoice/Index.php
@@ -45,7 +45,7 @@ class Index extends \Magento\Framework\App\Action\Action{
       try{
          if($order->getId()){
             if($order->getCustomerId() == $this->getCustomer()){
-               if ($order->getPayment()->getMethodInstance()->getCode() == 'coinremitter_checkout' && $order->getStatus() == "pending") {
+               if ($order->getPayment()->getMethodInstance()->getCode() == 'coinremitter_checkout' && $order->getState() == "new") {
 
                   $resultPage = $this->resultPageFactory->create();
                   $resultPage->getConfig()->getTitle()->prepend(__('Order Invoice #'.$order->getIncrementId()));


### PR DESCRIPTION
In some stores we have custom default pending status like "not_paid", "waiting_payment". So the invoice controller redirects to home page. If we read Order state (Usually new for new orders), instead status, the controller works for any custom pending status.